### PR TITLE
Sign the default/fallback loader

### DIFF
--- a/sicherboot
+++ b/sicherboot
@@ -172,8 +172,11 @@ BOOTCTL_HELP="Usage: sicherboot bootctl [<argument> ...]
   systemd-boot${EFI_ARCH}.efi
 "
 bootctl() {
-    command bootctl --path="$BOOT_EFI_DIR" "$@"
-    sign_image "$BOOT_EFI_DIR/EFI/systemd/systemd-boot${EFI_ARCH}.efi"
+    PATHS=`command bootctl --path="$BOOT_EFI_DIR" "$@" 2>&1 | grep $BOOT_EFI_DIR | cut -d'"' -f 4`
+    for item in $PATHS
+    do
+      sign_image "$item"
+    done
 }
 
 

--- a/tests/test-setup
+++ b/tests/test-setup
@@ -50,6 +50,7 @@ testsuccess test -e tmp/efi/loader/entries/machine-id-keytool.conf
 cat >> $PWD/tmp/bootctl << EOF
 #!/bin/sh
 install -D /usr/lib/systemd/boot/efi/systemd-boot${EFI_ARCH}.efi $PWD/tmp/efi/EFI/systemd/systemd-boot${EFI_ARCH}.efi
+echo "Copied \"/usr/lib/systemd/boot/efi/systemd-boot${EFI_ARCH}.efi\" to \"$PWD/tmp/efi/EFI/systemd/systemd-bootx64.efi\"."
 EOF
 
 chmod +x $PWD/tmp/bootctl


### PR DESCRIPTION
Apart from installing systemd-boot at /EFI/systemd/*, bootctl also installs a
default/fallback loader at /EFI/BOOT/BOOT*.EFI. Sign this loader too.

